### PR TITLE
fix: resolve Prisma enum import issues in seed file

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,18 @@
-import { Day, PrismaClient, UserSex } from "@prisma/client";
+import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
+
+enum UserSex {
+  MALE = "MALE",
+  FEMALE = "FEMALE"
+}
+
+enum Day {
+  MONDAY = "MONDAY",
+  TUESDAY = "TUESDAY",
+  WEDNESDAY = "WEDNESDAY",
+  THURSDAY = "THURSDAY",
+  FRIDAY = "FRIDAY"
+}
 
 async function main() {
   // ADMIN


### PR DESCRIPTION
Fixed an issue where the seed file was failing due to incorrect enum imports from the Prisma client. The error occurred because the enums (Day and UserSex) were not being properly imported from @prisma/client, causing TypeScript compilation errors.

Changes Made:
- Removed direct enum imports from @prisma/client
- Added local enum definitions in seed.ts that match the Prisma schema
- Defined UserSex and Day enums with their exact values as specified in schema.prisma

Impact:
- Resolves TypeScript compilation errors
- Enables successful database seeding
- Maintains type safety while working with enums

Testing:
- Verified that TypeScript compilation succeeds
- Confirmed that `npx prisma db seed` runs without errors
- Validated that the enum values match the database schema